### PR TITLE
fix: replace broken uConsole KVM Extension hero image URL

### DIFF
--- a/src/data/products/kvmext.ts
+++ b/src/data/products/kvmext.ts
@@ -21,9 +21,9 @@ export const kvmextProduct: Product = {
   keywords:
     "uConsole, extensión KVM, KVM portátil, Clockwork uConsole",
   heroImage:
-    'https://assets.openterface.com/images/uconsole-kvm-extension/uconsole-kvm-extension-1.webp',
+    'https://assets.openterface.com/images/cover/uconsole.webp',
   heroImages: [
-    'https://assets.openterface.com/images/uconsole-kvm-extension/uconsole-kvm-extension-1.webp',
+    'https://assets.openterface.com/images/cover/uconsole.webp',
     'https://assets.openterface.com/images/product/openterface-kvm-uconsole-extension.webp',
   ],
   buyLabel: "Saber Más",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix broken hero image for uConsole KVM Extension product. The old URL (`uconsole-kvm-extension/uconsole-kvm-extension-1.webp`) returns 404. Replaced with working `images/cover/uconsole.webp`.

Same fix applied across all locale repos — see openterface_en PR for full details and verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74f6c72f-7741-4b6c-bfd3-ec3deb4c5977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74f6c72f-7741-4b6c-bfd3-ec3deb4c5977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

